### PR TITLE
encoding: implement an encoding class for multiple metrics taking

### DIFF
--- a/include/Encoder.hh
+++ b/include/Encoder.hh
@@ -1,0 +1,89 @@
+#ifndef ENCODER_HH
+#define ENCODER_HH
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <sstream>
+
+/**
+ * LogHandle - logs data to both stdout and a string stream
+ */
+class LogHandle {
+ public:
+  LogHandle(std::stringstream& ss) : stream(ss) {}
+  template <typename T>
+  LogHandle& operator<<(const T& data) {
+    stream << data;
+    std::cout << data;
+    return *this;
+  }
+  std::stringstream& stream;
+};
+
+/**
+ * Encoder - multiplexes multiple outputs into a combined format
+ *
+ * The idea is to provide benchmarks with a means for writing their logs and
+ * metrics out into a single file that contains a human readable section as
+ * well as a machine-parsable portion of metrics.
+ */
+class Encoder {
+ public:
+  Encoder() : log_(files_[logFile]) {}
+
+  std::stringstream& operator[](const std::string& filename) {
+    if (filename == logFile)
+      throw std::runtime_error(std::string(logFile) + " is reserved");
+    return files_[filename];
+  }
+
+  void debugDumpAll(std::ostream& os) const {
+    for (const auto& [filename, ss] : files_) {
+      os << "### " << filename << " ###\n";
+      os << ss.str() << "\n";
+    }
+  }
+
+  LogHandle& log() {
+    log_ << fmtTimestamp();
+    return log_;
+  }
+
+  void exportAll(const std::string& benchName) const {
+    const std::filesystem::path dirname = genFileName(benchName);
+    std::filesystem::create_directories(dirname);
+    for (const auto& [filename, ss] : files_) {
+      std::ofstream out(dirname / filename);
+      out << ss.str();
+    }
+    std::cout << fmtTimestamp() << " wrote results to " << dirname << std::endl;
+  }
+
+ private:
+  static constexpr const char* logFile = "log.out";
+  std::map<std::string, std::stringstream> files_;
+  LogHandle log_;
+
+  static std::string fmtTimestamp() {
+    auto now = std::chrono::high_resolution_clock::now();
+    auto time = std::chrono::system_clock::to_time_t(now);
+    char buf[100];
+    std::strftime(buf, sizeof(buf), "[%Y-%m-%d %H:%M:%S]", std::localtime(&time));
+    std::stringstream ss;
+    ss << buf << " ";
+    return ss.str();
+  }
+
+  static std::string genFileName(const std::string& benchName) {
+    auto now = std::chrono::high_resolution_clock::now();
+    auto time = std::chrono::system_clock::to_time_t(now);
+    char buf[100];
+    std::strftime(buf, sizeof(buf), "%H_%M_%S", std::localtime(&time));
+    return benchName + "_" + buf;
+  }
+};
+
+#endif /* ENCODER_HH */

--- a/include/PchaseGPUBenchmark.hh
+++ b/include/PchaseGPUBenchmark.hh
@@ -43,7 +43,7 @@ class PChaseGPUBenchmark {
  public:
   static constexpr const char* benchmarkName = "pchase_gpu";
 
-  PChaseGPUBenchmark(const std::vector<std::string>& args = {}) {
+  PChaseGPUBenchmark(Encoder& e, const std::vector<std::string>& args = {}) : enc_(e) {
     benchmark::ArgParser parser(args);
     numExperiments_ = parser.getOr("num_experiments", 12UL);
     multiplier_ = parser.getOr("multiplier", 2UL);
@@ -59,7 +59,7 @@ class PChaseGPUBenchmark {
 
   std::string name() const { return benchmarkName; }
 
-  void run(std::ostream& os) {
+  void run() {
     /* Step 1: take coarse grained measurements, multiplying the effective size
      * of the chain by 2 every iteration. This detects approximately where large
      * increases in access latency occur. */
@@ -81,12 +81,13 @@ class PChaseGPUBenchmark {
      * for access latency. */
     double clockLatency = measureClock64Latency(numIters_);
 
-    os << "bytes,avg_access_latency\n";
+    enc_["latency.csv"] << "bytes,avg_access_latency\n";
     for (const auto& [bytes, avgLatency] : fine)
-      os << bytes << "," << (avgLatency - clockLatency) << "\n";
+      enc_["latency.csv"] << bytes << "," << (avgLatency - clockLatency) << "\n";
   }
 
  private:
+  Encoder& enc_;
   uint64_t numExperiments_;
   uint64_t multiplier_;
   uint64_t numIters_;

--- a/src/main.cc
+++ b/src/main.cc
@@ -17,9 +17,11 @@ int main(int argc, char** argv) {
   std::string name = argv[1];
   const std::vector<std::string> args(argv + 2, argv + argc);
 
+  Encoder encoder;
   try {
     /* Run the benchmark, serialize the results to std::cout. */
-    benchmark::BenchmarkRegistry::instance().run(name, args, std::cout);
+    benchmark::BenchmarkRegistry::instance().run(name, encoder, args);
+    encoder.exportAll(name);
   } catch (std::out_of_range& e) {
     std::cerr << "Error: Unknown benchmark \"" << name << "\"\n";
     std::cerr << "Available benchmarks: ";


### PR DESCRIPTION
The Encoder class is an abstraction on top of string streams that makes it easier to record multiple metric types into different streams that can then be written out into separate files.

E.g., if a benchmark has latency measurements that should be exported in .csv format, and some other statistics in .txt, we could do

```c++
enc["latency.csv"] << "latency,measurements,here\n";
enc["stats.txt"] << "some stat\n";
```

The Encoder class also provides a `.log()` method that returns a stream that is written out into a log.out file, and also to stdout. Logs also include a formatted timestamp.