### PR TITLE
pchase_gpu: remove subtraction by clock64 latency in report

### DIFF
--- a/include/PchaseGPUBenchmark.hh
+++ b/include/PchaseGPUBenchmark.hh
@@ -84,7 +84,7 @@ class PChaseGPUBenchmark {
     enc_["clock64_latency"] << clockLatency << " cycles " << std::endl;
     enc_["latency.csv"] << "bytes,avg_access_latency\n";
     for (const auto& [bytes, avgLatency] : fine)
-      enc_["latency.csv"] << bytes << "," << (avgLatency - clockLatency) << "\n";
+      enc_["latency.csv"] << bytes << "," << avgLatency << "\n";
   }
 
  private:


### PR DESCRIPTION
As we are implementing a coarse-grained pointer-chase algorithm, where timing happens before and after a large number of accesses, it is incorrect to subtract the clock64() latency from the average latency in the report.