### PR TITLE
clock64.cu: add helper for reading maximum clock64 frequency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update
-          sudo apt-get -y install cuda-nvcc-12-3 cuda-cudart-dev-12-3
+          sudo apt-get -y install cuda-nvcc-12-3 cuda-cudart-dev-12-3 cuda-nvml-dev-12-3
           echo "/usr/local/cuda-12.3/bin" >> $GITHUB_PATH
       
       - name: Verify CUDA installation

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 NVCC := nvcc
 NVCCFLAGS := -std=c++20 -O3
 NVCCFLAGS += -Werror all-warnings
+NVCCFLAGS += -lnvidia-ml
 NVCCFLAGS += -Xcompiler "-Wall,-Wextra,-Wconversion,-Wshadow"
 NVCCFLAGS += -Xcompiler "-Wno-unused-parameter"  # Often unavoidable in CUDA
 INCLUDES := -I./include

--- a/include/clock64.hh
+++ b/include/clock64.hh
@@ -6,4 +6,7 @@
 /** Host-callable wrapper. */
 double measureClock64Latency(uint64_t iters);
 
+/** Returns the maximum clock frequency in Hz. */
+unsigned int getMaxClockFrequencyHz();
+
 #endif /* CLOCK64_HH */


### PR DESCRIPTION
    clock64.cu: add helper for reading maximum clock64 frequency

    Adds a function, getMaxClockFrequencyHz(), that returns device 0's
    maximum clock frequency in Hz. In particular, this is the SM clock
    which corresponds to the frequency of the clock that clock64()
    probes.

    As this pulls in a new dependency for nvml, our workflows configuration
    is updated, as well as the Makefile that must link against it.